### PR TITLE
sort items by order in playlist file

### DIFF
--- a/RetroFE/Source/Collection/CollectionInfo.h
+++ b/RetroFE/Source/Collection/CollectionInfo.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_map>
 
 class Item;
 class Configuration;
@@ -50,6 +51,16 @@ public:
     bool subsSplit;
     bool hasSubs;
     bool sortDesc;
+
+    std::map<std::string, std::vector<std::string>> playlistOrders;
+    void readPlaylistFile(const std::string& playlistName);
+    std::vector<std::string> playlistOrder;
+    void readAllPlaylistFiles();
+    void customSortAllItems();
+    int findInPlaylistOrder(const std::string& itemName, const std::vector<std::string>& playlistOrder);
+    void customSortPlaylist(const std::string& playlistName, std::vector<Item*>* playlist);
+    void customSort(std::vector<Item*>& itemsToSort, const std::unordered_map<std::string, std::size_t>& orderIndices, const std::string& mainCollectionName);
+
 private:
     Configuration& conf_;
     std::string metadataPath_;

--- a/RetroFE/Source/Collection/CollectionInfoBuilder.h
+++ b/RetroFE/Source/Collection/CollectionInfoBuilder.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <map>
 #include <vector>
+#include "Item.h"
+#include "../RetroFE.h"
 
 class Configuration;
 class CollectionInfo;
@@ -48,4 +50,5 @@ private:
     void AddToPlayCount(Item* item);
     std::map<std::string, Item*> ImportPlayCount(std::string file);
     void ImportRomDirectory(std::string path, CollectionInfo *info, std::map<std::string, Item *> includeFilter, std::map<std::string, Item *> excludeFilter, bool romHierarchy, bool emuarc);
+    RetroFE* retroFEInstance;
 };

--- a/RetroFE/Source/RetroFE.cpp
+++ b/RetroFE/Source/RetroFE.cpp
@@ -2309,13 +2309,23 @@ CollectionInfo *RetroFE::getCollection(std::string collectionName)
         collection->sortItems();
     }
 
+    else {
+        // Sort items based on 'ctrlType'
+        collection->customSortAllItems();  // No need to pass sortType
+    }
     // build collection menu if menu.txt exists
     MenuParser mp;
     mp.buildMenuItems(collection, menuSort);
-
-    // adds items to "all" list except those found in "exclude_all.txt"
+    // Adds items to "all" list except those found in "exclude_all.txt"
     cib.addPlaylists(collection);
-    collection->sortPlaylists();
+
+    if (!menuSort) {
+        collection->customSortAllItems();  // No need to pass sortType
+        // Potentially add logic to sort other playlists here
+    }
+    else {
+        collection->sortPlaylists();
+    }
 
     // Add extra info, if available
     for ( std::vector<Item *>::iterator it = collection->items.begin( ); it != collection->items.end( ); it++ )


### PR DESCRIPTION
- if menusort=false items will be sorted by the order they're listed within the playlist file.

- Have edited the function to include an if statement to check if a playlist is named after a getMetaAttribute (excluding lastplayed) If it is, it will skip the custom sort, and sort by the meta attribute i.e., if a playlist name is year, the playlist will be sorted by year even if menusort=false. Will still sort other playlists by order they're listed.

- I've excluded lastplayed from the meta check, as it can be sorted via the new custom sort, and no longer requires reading from the playCount file as items will already be listed by lastplayed when added to this playlist.