### PR TITLE
playlist order now includes sub files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 v0.10.34.3
+    - fixed playlist order if menuSort=false for sub items (arghs15)
     - changed video pause/restart behavior, also videos will now pause by default if out of view, disablePauseOnScroll=true in settings.conf for global override. (inigomontoya)
     - reworked and streamlined gstreamer implementation (inigomontoya) 
     - fix randomSelect; bump version number (tcontreras)

--- a/RetroFE/Source/Collection/CollectionInfo.cpp
+++ b/RetroFE/Source/Collection/CollectionInfo.cpp
@@ -184,9 +184,9 @@ void CollectionInfo::addSubcollection(CollectionInfo *newinfo)
     items.insert(items.begin(), newinfo->items.begin(), newinfo->items.end());
 }
 
-auto CollectionInfo::itemIsLess(std::string sortType)
+auto CollectionInfo::itemIsLess(std::string sortType, bool currentCollectionMenusort)
 {
-    return [sortType](Item* lhs, Item* rhs) {
+    return [sortType, currentCollectionMenusort](Item* lhs, Item* rhs) {
 
         if (lhs->leaf && !rhs->leaf) return true;
         if (!lhs->leaf && rhs->leaf) return false;
@@ -211,7 +211,7 @@ auto CollectionInfo::itemIsLess(std::string sortType)
         }
 
         // menu sort is false then use playlist's order
-        if (!lhs->collectionInfo->menusort)
+        if (!currentCollectionMenusort)
             return false;
 
         // default sort by name
@@ -222,7 +222,7 @@ auto CollectionInfo::itemIsLess(std::string sortType)
 
 void CollectionInfo::sortItems()
 {
-    std::sort( items.begin(), items.end(), itemIsLess(""));
+    std::sort(items.begin(), items.end(), itemIsLess("", menusort));
 }
 
 
@@ -237,7 +237,7 @@ void CollectionInfo::sortPlaylists()
         {
             // temporarily set collection info's sortType so search has access to it
             sortType = Item::validSortType(itP->first) ? itP->first : "";
-            std::sort(itP->second->begin(), itP->second->end(), itemIsLess(sortType));
+            std::sort(itP->second->begin(), itP->second->end(), itemIsLess(sortType, menusort));
         }
     }
     sortType = "";

--- a/RetroFE/Source/Collection/CollectionInfo.h
+++ b/RetroFE/Source/Collection/CollectionInfo.h
@@ -32,7 +32,7 @@ public:
     void sortItems();
     void sortPlaylists();
     void addSubcollection(CollectionInfo *info);
-    static auto itemIsLess(std::string sortType);
+    auto itemIsLess(std::string sortType, bool currentCollectionMenusort);
     void extensionList(std::vector<std::string> &extensions);
     std::string name;
     std::string lowercaseName();


### PR DESCRIPTION
- menusort=false will also sort sub files
- logging suggested sub file items were printing out menusort=true, so were listed by title rather than order in the playlist. I guess it was grabbing the list.menusort value from their original collection.