### PR TITLE
change dos paths to unix

### DIFF
--- a/RetroFE/Source/Database/Configuration.cpp
+++ b/RetroFE/Source/Database/Configuration.cpp
@@ -25,6 +25,7 @@
 #include <string_view>
 #include <set>
 #include <cstdio>
+#include <algorithm>
 
 #ifdef WIN32
 #include <windows.h>
@@ -401,6 +402,12 @@ std::string Configuration::convertToAbsolutePath(const std::string& prefix, cons
 bool Configuration::getPropertyAbsolutePath(const std::string& key, std::string &value)
 {
     bool retVal = getProperty(key, value);
+    
+    #ifndef WIN32
+        // This is a catch me to change dos paths to unix
+        // Windows can resolve unix paths but not vice versa
+        std::replace(value.begin(), value.end(), '\\', '/');
+    #endif
 
     if(retVal)
     {


### PR DESCRIPTION
In windows builds list.path is typically "emulators\mame\roms", on unix systems this causes retrofe to load a blank collection because it didn't resolve to find the items. We can just have this as a catchme instead making porting quicker