### PR TITLE
Fix osx arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ Download the following .dmg and place all .framework's in `RetroFE/ThirdPartyMac
 * Install Gstreamer (https://gstreamer.freedesktop.org/download/#macos)
 * * For Gstreamer both runtime and dev packages are needed, they are installed to `Macintosh HD/Library/Frameworks` and should be moved to `RetroFE/ThirdPartyMac`
 
+### Install headers
+
+```bash
+brew install minizip libusb
+```
+
 ### Download and compile the source code
 Download the source code
 

--- a/RetroFE/Source/CMakeLists.txt
+++ b/RetroFE/Source/CMakeLists.txt
@@ -78,6 +78,14 @@ elseif(APPLE)
     find_package(SDL2_mixer REQUIRED)
     find_package(SDL2_ttf REQUIRED)
     find_package(ZLIB REQUIRED)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(IOKIT IOKit)
+    pkg_check_modules(GLIB2 REQUIRED glib-2.0 gobject-2.0 gthread-2.0)
+    pkg_check_modules(GST REQUIRED gstreamer-1.0 gstreamer-video-1.0 gstreamer-plugins-base-1.0)
+
+    # Manually specify paths if needed
+    set(LIBUSB_INCLUDE_DIR "/opt/homebrew/include" CACHE PATH "Path to libusb include directory")
+    set(LIBUSB_LIBRARY "/opt/homebrew/lib/libusb-1.0.dylib" CACHE FILEPATH "Path to libusb library")
     
 else()
     include(FindPkgConfig)
@@ -110,6 +118,7 @@ else()
         ${GLIB2_INCLUDE_DIRS}
         ${Threads_INCLUDE_DIRS}
         ${LIBUSB_INCLUDE_DIRS}
+        ${LIBUSB_INCLUDE_DIR}
         ${LIBEVDEV_INCLUDE_DIRS}
     )
     
@@ -307,20 +316,73 @@ set(LIBRARY_OUTPUT_PATH "${RETROFE_DIR}/Build" CACHE PATH "Build directory" FORC
 include_directories(${RETROFE_INCLUDE_DIRS})
 add_executable(retrofe  ${RETROFE_SOURCES} ${RETROFE_HEADERS})
 
-if(NOT WIN32)
-    target_link_libraries(retrofe 
-        ${RETROFE_LIBRARIES}
-        webpdemux
-	    webp
-        minizip
-    )
+find_library(WEBPDEMUX_LIBRARY
+    NAMES webpdemux
+    HINTS /opt/homebrew/lib /usr/lib /usr/local/lib
+)
+
+find_library(WEBP_LIBRARY
+    NAMES webp
+    HINTS /opt/homebrew/lib /usr/lib /usr/local/lib
+)
+
+find_library(MINIZIP_LIBRARY
+    NAMES minizip
+    HINTS /opt/homebrew/lib /usr/lib /usr/local/lib
+)
+
+if(WEBPDEMUX_LIBRARY)
+    message(STATUS "Found webpdemux: ${WEBPDEMUX_LIBRARY}")
+    set(HAVE_WEBPDEMUX TRUE)
 else()
-target_link_libraries(retrofe 
-        ${RETROFE_LIBRARIES})
+    message(WARNING "webpdemux not found; assuming it's bundled in libwebp")
+    set(HAVE_WEBPDEMUX FALSE)
 endif()
 
+if(WEBP_LIBRARY)
+    message(STATUS "Found webp: ${WEBP_LIBRARY}")
+    set(HAVE_WEBP TRUE)
+else()
+    message(WARNING "webp not found; assuming it's bundled in libwebp")
+    set(HAVE_WEBP FALSE)
+endif()
+
+if(MINIZIP_LIBRARY)
+    message(STATUS "Found minizip: ${MINIZIP_LIBRARY}")
+    set(HAVE_MINIZIP TRUE)
+else()
+    message(WARNING "minizip not found")
+    set(HAVE_MINIZIP FALSE)
+endif()
+
+if(HAVE_WEBPDEMUX)
+    target_link_libraries(retrofe ${WEBPDEMUX_LIBRARY})
+endif()
+
+if(HAVE_WEBP)
+    target_link_libraries(retrofe ${WEBP_LIBRARY})
+endif()
+
+if(HAVE_MINIZIP)
+    target_link_libraries(retrofe ${MINIZIP_LIBRARY})
+endif()
+
+target_link_libraries(retrofe ${RETROFE_LIBRARIES})
 
 if(APPLE)
+    target_link_libraries(retrofe
+        ${COREFOUNDATION}
+        ${IOKIT}
+        ${SDL2_LIBRARIES}
+        ${SDL2_IMAGE_LIBRARIES}
+        ${SDL2_MIXER_LIBRARIES}
+        ${SDL2_TTF_LIBRARIES}
+        ${LIBUSB_LIBRARY}
+        ${GLIB2_LIBRARIES}
+        ${GSTREAMER_LIBRARIES}
+        ${GSTREAMER_VIDEO_LIBRARIES}
+    )
+    
     # Set up macOS-specific properties
     set_target_properties(retrofe PROPERTIES OUTPUT_NAME "retrofe-${GIT_COMMIT_NO}")
     set_target_properties(retrofe PROPERTIES LINKER_LANGUAGE CXX)

--- a/RetroFE/Source/Graphics/Component/Image.cpp
+++ b/RetroFE/Source/Graphics/Component/Image.cpp
@@ -19,8 +19,15 @@
 #include "../../SDL.h"           // Ensure this header declares SDL::getRenderer and SDL::getMutex
 #include "../../Utility/Log.h"
 
-#ifdef __APPLE__
+#if __has_include(<SDL2/SDL_image.h>)
+#include <SDL2/SDL_image.h>
+#elif __has_include(<SDL2_image/SDL_image.h>)
 #include <SDL2_image/SDL_image.h>
+#else
+#error "Cannot find SDL_image header"
+#endif
+
+#ifdef __APPLE__
 #include <webp/decode.h>
 #include <webp/demux.h>
 #elif defined(_WIN32) 
@@ -28,7 +35,6 @@
 #include <decode.h>
 #include <demux.h>
 #else  // Assume Linux
-#include <SDL2/SDL_image.h>
 #include <webp/decode.h>
 #include <webp/demux.h>
 #endif

--- a/RetroFE/Source/Graphics/Component/Image.h
+++ b/RetroFE/Source/Graphics/Component/Image.h
@@ -19,8 +19,14 @@
 #include <string>
 #include "Component.h"
 #include <SDL2/SDL.h>
-#ifdef __APPLE__
+#if __has_include(<SDL2/SDL_image.h>)
+#include <SDL2/SDL_image.h>
+#elif __has_include(<SDL2_image/SDL_image.h>)
 #include <SDL2_image/SDL_image.h>
+#else
+#error "Cannot find SDL_image header"
+#endif
+#ifdef __APPLE__
 #include <webp/decode.h>
 #include <webp/demux.h>
 #elif defined(_WIN32) 
@@ -28,7 +34,6 @@
 #include <decode.h>
 #include <demux.h>
 #else  // Assume Linux
-#include <SDL2/SDL_image.h>
 #include <webp/decode.h>
 #include <webp/demux.h>
 #endif

--- a/RetroFE/Source/Graphics/Component/ScrollingList.cpp
+++ b/RetroFE/Source/Graphics/Component/ScrollingList.cpp
@@ -36,10 +36,12 @@
 #include "../../SDL.h"
 #include "../ViewInfo.h"
 #include <math.h>
-#if (__APPLE__)
-    #include <SDL2_image/SDL_image.h>
+#if __has_include(<SDL2/SDL_image.h>)
+#include <SDL2/SDL_image.h>
+#elif __has_include(<SDL2_image/SDL_image.h>)
+#include <SDL2_image/SDL_image.h>
 #else
-    #include <SDL2/SDL_image.h>
+#error "Cannot find SDL_image header"
 #endif
 #include <sstream>
 #include <cctype>

--- a/RetroFE/Source/Graphics/Font.cpp
+++ b/RetroFE/Source/Graphics/Font.cpp
@@ -17,10 +17,12 @@
 #include "../SDL.h"
 #include "../Utility/Log.h"
 #include <SDL2/SDL.h>
-#if (__APPLE__)
+#if __has_include(<SDL2/SDL_ttf.h>)
+#include <SDL2/SDL_ttf.h>
+#elif __has_include(<SDL2_ttf/SDL_ttf.h>)
 #include <SDL2_ttf/SDL_ttf.h>
 #else
-#include <SDL2/SDL_ttf.h>
+#error "Cannot find SDL_ttf header"
 #endif
 #include <cstdio>
 #include <cstring>

--- a/RetroFE/Source/Graphics/Font.h
+++ b/RetroFE/Source/Graphics/Font.h
@@ -16,11 +16,14 @@
 #pragma once
 
 #include <SDL2/SDL.h>
-#if (__APPLE__)
+#if __has_include(<SDL2/SDL_ttf.h>)
+#include <SDL2/SDL_ttf.h>
+#elif __has_include(<SDL2_ttf/SDL_ttf.h>)
 #include <SDL2_ttf/SDL_ttf.h>
 #else
-#include <SDL2/SDL_ttf.h>
+#error "Cannot find SDL_ttf header"
 #endif
+
 #include <string>
 #include <unordered_map>
 

--- a/RetroFE/Source/Graphics/FontCache.cpp
+++ b/RetroFE/Source/Graphics/FontCache.cpp
@@ -18,10 +18,12 @@
 #include "../SDL.h"
 #include "../Utility/Log.h"
 #include "Font.h"
-#if (__APPLE__)
+#if __has_include(<SDL2/SDL_ttf.h>)
+#include <SDL2/SDL_ttf.h>
+#elif __has_include(<SDL2_ttf/SDL_ttf.h>)
 #include <SDL2_ttf/SDL_ttf.h>
 #else
-#include <SDL2/SDL_ttf.h>
+#error "Cannot find SDL_ttf header"
 #endif
 #include <sstream>
 #include <memory>

--- a/RetroFE/Source/Graphics/PageBuilder.h
+++ b/RetroFE/Source/Graphics/PageBuilder.h
@@ -18,10 +18,12 @@
 #include "Component/Image.h"
 #include "FontCache.h"
 #include <SDL2/SDL.h>
-#if (__APPLE__)
-    #include <SDL2_mixer/SDL_mixer.h>
+#if __has_include(<SDL2/SDL_mixer.h>)
+#include <SDL2/SDL_mixer.h>
+#elif __has_include(<SDL2_mixer/SDL_mixer.h>)
+#include <SDL2_mixer/SDL_mixer.h>
 #else
-    #include <SDL2/SDL_mixer.h>
+#error "Cannot find SDL_mixer header"
 #endif
 #include <rapidxml.hpp>
 #include <vector>

--- a/RetroFE/Source/RetroFE.cpp
+++ b/RetroFE/Source/RetroFE.cpp
@@ -41,10 +41,12 @@
 #include <string>
 #include <tuple>
 #include <vector>
-#if (__APPLE__)
+#if __has_include(<SDL2/SDL_ttf.h>)
+#include <SDL2/SDL_ttf.h>
+#elif __has_include(<SDL2_ttf/SDL_ttf.h>)
 #include <SDL2_ttf/SDL_ttf.h>
 #else
-#include <SDL2/SDL_ttf.h>
+#error "Cannot find SDL_ttf header"
 #endif
 
 #if defined(__linux) || defined(__APPLE__)

--- a/RetroFE/Source/RetroFE.h
+++ b/RetroFE/Source/RetroFE.h
@@ -26,10 +26,12 @@
 #include "Video/VideoFactory.h"
 #include "Video/GStreamerVideo.h"
 #include <SDL2/SDL.h>
-#if (__APPLE__)
-    #include <SDL2_ttf/SDL_ttf.h>
+#if __has_include(<SDL2/SDL_ttf.h>)
+#include <SDL2/SDL_ttf.h>
+#elif __has_include(<SDL2_ttf/SDL_ttf.h>)
+#include <SDL2_ttf/SDL_ttf.h>
 #else
-    #include <SDL2/SDL_ttf.h>
+#error "Cannot find SDL_ttf header"
 #endif
 #include <list>
 #include <stack>

--- a/RetroFE/Source/SDL.cpp
+++ b/RetroFE/Source/SDL.cpp
@@ -19,10 +19,12 @@
 #include "Database/Configuration.h"
 #include "Database/GlobalOpts.h"
 #include "Utility/Log.h"
-#if (__APPLE__)
+#if __has_include(<SDL2/SDL_mixer.h>)
+#include <SDL2/SDL_mixer.h>
+#elif __has_include(<SDL2_mixer/SDL_mixer.h>)
 #include <SDL2_mixer/SDL_mixer.h>
 #else
-#include <SDL2/SDL_mixer.h>
+#error "Cannot find SDL_mixer header"
 #endif
 #include "Utility/Utils.h"
 

--- a/RetroFE/Source/Sound/Sound.h
+++ b/RetroFE/Source/Sound/Sound.h
@@ -16,10 +16,12 @@
 #pragma once
 
 #include <string>
-#if (__APPLE__)
-    #include <SDL2_mixer/SDL_mixer.h>
+#if __has_include(<SDL2/SDL_mixer.h>)
+#include <SDL2/SDL_mixer.h>
+#elif __has_include(<SDL2_mixer/SDL_mixer.h>)
+#include <SDL2_mixer/SDL_mixer.h>
 #else
-    #include <SDL2/SDL_mixer.h>
+#error "Cannot find SDL_mixer header"
 #endif
 
 class Sound

--- a/RetroFE/Source/Video/GStreamerVideo.h
+++ b/RetroFE/Source/Video/GStreamerVideo.h
@@ -28,8 +28,15 @@
 
 extern "C" {
 #if (__APPLE__)
-#include <GStreamer/gst/gst.h>
-#include <GStreamer/gst/video/video.h>
+    #if __has_include(<gstreamer-1.0/gst/gst.h>)
+    #include <gstreamer-1.0/gst/gst.h>
+    #include <gstreamer-1.0/gst/video/video.h>
+    #elif __has_include(<GStreamer/gst/gst.h>)
+    #include <GStreamer/gst/gst.h>
+    #include <GStreamer/gst/video/video.h>
+    #else
+    #error "Cannot find Gstreamer headers"
+    #endif
 #else
 #include <gst/gst.h>
 #include <gst/pbutils/pbutils.h>

--- a/RetroFE/xcode/retrofe.xcodeproj/project.pbxproj
+++ b/RetroFE/xcode/retrofe.xcodeproj/project.pbxproj
@@ -632,6 +632,7 @@
 					"$(PROJECT_DIR)/../ThirdParty/rapidxml-1.13",
 					"$(PROJECT_DIR)/../ThirdPartyMac/GStreamer.framework/Headers",
 					/opt/homebrew/include,
+					/usr/local/include,
 				);
 				INFOPLIST_FILE = "$(PROJECT_DIR)/../xcode/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = RetroFE;
@@ -686,6 +687,7 @@
 					"$(PROJECT_DIR)/../ThirdParty/rapidxml-1.13",
 					"$(PROJECT_DIR)/../ThirdPartyMac/GStreamer.framework/Headers",
 					/opt/homebrew/include,
+					/usr/local/include,
 				);
 				INFOPLIST_FILE = "$(PROJECT_DIR)/../xcode/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = RetroFE;


### PR DESCRIPTION
Fixes building on macOS with cmake
Overhauls include paths to what they should be
Adds even more to cmakelists just for now
Builds macOS statically as an executable not AppBundle